### PR TITLE
Fix Notifier check

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -76,7 +76,7 @@ class Notifier
             $opt['keysBlocklist'] = $opt['keysBlacklist'];
         }
 
-        if (empty($opt['remoteConfig'])) {
+        if (!isset($opt['remoteConfig'])) {
             $opt['remoteConfig'] = true;
         }
 


### PR DESCRIPTION
The library was activating `remoteConfig` when it was set to `false`, giving the user no option to disable it.